### PR TITLE
Allow research page feature images to show up on Netlify deployments

### DIFF
--- a/_includes/portfolio.html
+++ b/_includes/portfolio.html
@@ -33,7 +33,7 @@
                                         {% if page.type == "research" %}
                                             {% if post.image.feature %}
                                                 <div class="img-container" style="margin-bottom: 12px; max-width:{% if post.image.size %} {{ post.image.size }}{% else %} 100%{% endif %};">
-                                                    <img classs="img-fluid img-centered" src="{{ site.url }}/img/{{ post.image.feature }}" alt="{{ post.title }}">
+                                                    <img classs="img-fluid img-centered" src="/img/{{ post.image.feature }}" alt="{{ post.title }}">
                                                 </div>
                                             {% endif %}
                                         {{ post.excerpt }}


### PR DESCRIPTION
Currently the images are sourced from `https://hiro-group.ronc.one/`, which doesn't work if the images aren't merged into master yet.