### PR TITLE
Fix Netlify Deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby '2.7.2'
+ruby '3.3.3'
 gem 'github-pages'
 gem "webrick", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
 ruby '2.7.2'
-gem 'jekyll', '~> 4.2.0'
 gem 'github-pages'
-
 gem "webrick", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 ruby '3.3.3'
+
 gem 'github-pages'
 gem "webrick", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
+
+ruby '2.7.2'
+gem 'jekyll', '~> 4.2.0'
 gem 'github-pages'
 
 gem "webrick", "~> 1.8"


### PR DESCRIPTION
This PR fixes the netlify deploy issue:

1. Updates the ruby version to `3.3.3` (latest stable version), which does not cause the version issue that was blocking deploys working.